### PR TITLE
Feat: 实现光速飞船卡牌的操作逻辑

### DIFF
--- a/data/player.py
+++ b/data/player.py
@@ -53,6 +53,7 @@ class Player:
         self.broadcasts: list[Broadcast] = []
         self.connect_ID: str = ""
         self.memories: list[int] = []
+        self.used_operations: list[type[OperationCard]] = []
         logger.debug(f"玩家初始化完成: 初始能量={self.energy}")
 
     def start_game(self) -> None:
@@ -417,6 +418,12 @@ class Player:
                 f"玩家{self.number}操作失败: 该卡牌不是操作卡 (类型={type(card)})"
             )
             return False, "该卡牌不是操作卡"
+        if Tags.ONLY_ONE in card.tags:
+            if type(card) in self.used_operations:
+                logger.warning(
+                    f"玩家{self.number}操作失败: 该操作卡只能使用一次 (卡牌={card.name})"
+                )
+                return False, "该操作卡只能使用一次"
         if self.energy < card.cost:
             logger.warning(
                 f"玩家{self.number}操作失败: 能量不足 (当前能量={self.energy}, 需要={card.cost})"
@@ -426,6 +433,8 @@ class Player:
         self.energy -= card.cost
         self.cards.remove(card)
         result = card.operate(self)
+        if Tags.ONLY_ONE in card.tags:
+            self.used_operations.append(type(card))
         logger.info(
             f"玩家{self.number}操作成功: 卡牌={card.name}, 能量消耗={card.cost} ({old_energy}->{self.energy}), 结果={result}"
         )


### PR DESCRIPTION
**概述**
本PR实现了光速飞船卡牌的操作逻辑，包括添加ONLY_ONE标签检查机制和实现光速飞船的跃迁功能。

**实现的功能**

1. **添加ONLY_ONE标签检查**
   - 问题：operate方法没有处理ONLY_ONE标签，导致只能使用一次的操作卡可以被重复使用
   - 修复：在Player类中添加used_operations属性，在operate方法中检查并记录使用过的操作卡

2. **实现光速飞船的operate方法**
   - 问题：光速飞船卡牌已定义但operate方法未实现
   - 修复：实现完整的跃迁逻辑，包括星球选择、能量清空、建筑清空、星球所有者更新等

**影响范围**
- data/player.py: 添加used_operations属性，在operate方法中添加ONLY_ONE标签检查
- data/card.py: 实现LightSpeedShip类的operate方法

**测试建议**
1. 测试光速飞船的跃迁功能：使用后玩家是否移动到随机星球
2. 测试能量清空：使用后玩家能量是否被清空
3. 测试建筑清空：使用后玩家建筑是否被清空
4. 测试只能使用一次：尝试第二次使用光速飞船是否被正确拒绝
5. 测试边界情况：当没有可用星球时是否正确处理

**关闭的Issues**
Closes #27