### PR TITLE
Feat: 实现强制回复自己星系的广播功能

### DIFF
--- a/data/connect_manager.py
+++ b/data/connect_manager.py
@@ -180,6 +180,7 @@ class ConnectManager:
                 "start_game": handler.start_game,
                 "start_round": handler.start_round,
                 "apply_attack": handler.apply_attack,
+                "need_respond": handler.need_respond,
                 "other_operation": handler.other_operation,
             }
 
@@ -305,6 +306,29 @@ class Handler:
             return False
         else:
             return False
+
+    def need_respond(self, player: Player):
+        if player.planet is None:
+            return False
+        output = "你和星系上拥有了一个广播，你需要回复,请输入用来回复的卡牌的编号,卡牌:"
+        for i, card in enumerate(player.cards):
+            output += f"{card.name}({card.cost}, {i}号) "
+        self.output(output)
+        while True:
+            ret = self.input()
+            if ret.isdigit():
+                card_id = int(ret)
+                if 0 <= card_id < len(player.cards):
+                    ret, doc = player.respond_broadcast(card_id, player.planet.number)
+                    if ret:
+                        self.output(f"回复成功, {doc}")
+                        return True
+                    else:
+                        self.output(f"回复失败: {doc}请重新输入")
+                else:
+                    self.output("输入错误，请重新输入")
+            else:
+                self.output("输入错误，请重新输入")
 
     def other_operation(self, operation: Message):
         self.output(f"收到其他操作: {message_to_str(operation)}")


### PR DESCRIPTION
**概述**&#10;&#10;本PR实现了强制回复自己星系的广播功能，确保玩家在收到针对自己星系的广播时必须进行回应，符合黑暗森林游戏规则。&#10;&#10;**修复的问题**&#10;&#10;1. **Bug #33**: 强制回复自己星系的广播&#10;   - 问题：根据黑暗森林游戏规则，当其他玩家对自己的星系发起广播时，被广播的玩家必须回应该广播。当前游戏中没有强制要求玩家回应广播，玩家可以选择无视，这违反了游戏规则。&#10;   - 修复：在Player.check_broadcasts中添加强制回应检查逻辑，当检测到玩家星系上有未回应的广播且手牌中有可用广播卡时，调用need_respond函数强制玩家回应。在Handler类中实现need_respond方法，提供用户交互界面。&#10;&#10;**影响范围**&#10;&#10;- data/player.py: check_broadcasts方法（添加functions参数和强制回应逻辑）&#10;- data/connect_manager.py: Handler.need_respond方法（新增）、refresh_function_map方法（注册need_respond）&#10;&#10;**测试建议**&#10;&#10;1. 测试玩家A对玩家B的星系发起广播，验证玩家B是否被强制要求回应&#10;2. 测试玩家手牌中没有可用广播卡时，是否不触发强制回应&#10;3. 测试玩家星系上没有广播时，是否不触发强制回应&#10;4. 测试回应成功后，广播是否正常结束&#10;5. 测试回应失败时，是否允许重新选择卡牌&#10;&#10;**关闭的Issues**&#10;&#10;Closes #33